### PR TITLE
Properly handle strings that are near a page boundary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ license = "MIT"
 
 [dev-dependencies]
 quickcheck = "*"
+libc = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![feature(asm)]
 #![feature(core)]
-#![cfg_attr(test, feature(test, libc, collections))]
+#![cfg_attr(test, feature(test))]
 
 //!
 //! A tiny library to efficiently search strings for ASCII characters.
@@ -176,13 +176,11 @@ unsafe impl<'a> Searcher<'a> for AsciiCharsSearcher<'a> {
 mod test {
     extern crate quickcheck;
     extern crate libc;
-    extern crate core;
 
     use super::AsciiChars;
     use self::quickcheck::quickcheck;
     use std::str::pattern::{Pattern,Searcher,SearchStep};
-    use std::slice;
-    use std::str;
+    use std::{slice,str,ptr};
 
     pub const SPACE: AsciiChars       = AsciiChars { needle: 0x0000000000000020, count: 1 };
     // a
@@ -299,64 +297,61 @@ mod test {
     #[cfg(not(target_os = "macos"))]
     const MAP_ANONYMOUS: libc::int32_t = libc::MAP_ANONYMOUS;
 
-    unsafe fn alloc_guarded_string(value: &str, protect: bool) -> &'static str {
-        // Allocate a (leaked) pointer to a copy of value with protected end,
-        // i.e. returned copy is guaranteed to be aligned to page end,
-        // while the memory directly after its end is read-protected
+    fn alloc_guarded_string(value: &str, protect: bool) -> &'static str {
+        // Allocate a string that ends directly before a
+        // read-protected page.
         //
-        // Allocated memory is not freed (memory is leaked two pages per call),
-        // though it's acceptable for use in tests only.
-
-        use std::raw::Repr;
+        // This function leaks two pages of memory per call, which is
+        // acceptable for use in tests only.
 
         const PAGE_SIZE: usize = 4096;
+        assert!(value.len() <= PAGE_SIZE);
 
-        let repr = value.repr();
-        assert!(repr.len <= PAGE_SIZE);
+        unsafe {
+            // Map two rw-accessible pages of anonymous memory
+            let first_page = libc::mmap(
+                /* addr   = */ 0 as *mut libc::c_void,
+                /* length = */ 2 * PAGE_SIZE as libc::size_t,
+                /* prot   = */ libc::PROT_READ | libc::PROT_WRITE,
+                /* flags  = */ libc::MAP_PRIVATE | MAP_ANONYMOUS,
+                /* fd     = */ -1,
+                /* offset = */ 0,
+                );
+            assert!(!first_page.is_null());
 
-        // Map two rw-accessible pages of anonymous memory
-        let first_page = libc::mmap(
-            /* addr   = */ 0 as *mut libc::c_void,
-            /* length = */ 2 * PAGE_SIZE as libc::size_t,
-            /* prot   = */ libc::PROT_READ | libc::PROT_WRITE,
-            /* flags  = */ libc::MAP_PRIVATE | MAP_ANONYMOUS,
-            /* fd     = */ -1,
-            /* offset = */ 0,
-        );
-        assert!(!first_page.is_null());
+            let second_page = first_page.offset(PAGE_SIZE as isize);
 
-        let second_page = first_page.offset(PAGE_SIZE as isize);
+            if protect {
+                // Prohibit any access to the second page, so that any attempt
+                // to read or write it would trigger a segfault
+                let mprotect_retval = libc::mprotect(
+                    /* addr   = */ second_page,
+                    /* length = */ PAGE_SIZE as libc::size_t,
+                    /* prot   = */ libc::PROT_NONE,
+                    );
+                assert_eq!(0, mprotect_retval);
+            }
 
-        if protect {
-            // Prohibit any access to the second page, so that any attempt
-            // to read or write it would trigger a segfault
-            let mprotect_retval = libc::mprotect(
-                /* addr   = */ second_page,
-                /* length = */ PAGE_SIZE as libc::size_t,
-                /* prot   = */ libc::PROT_NONE,
-            );
-            assert_eq!(0, mprotect_retval);
+            // Copy bytes to the end of the first page
+            let start = second_page.offset(-(value.len() as isize)) as *mut u8;
+            ptr::copy_nonoverlapping(value.as_ptr(), start, value.len());
+            str::from_utf8_unchecked(slice::from_raw_parts(start, value.len()))
         }
-
-        // Copy bytes to the end of the first page
-        let start = first_page.offset((PAGE_SIZE - repr.len) as isize) as *mut u8;
-        self::core::intrinsics::copy(repr.data, start, repr.len);
-        str::from_utf8_unchecked(slice::from_raw_parts(start, repr.len))
     }
 
     #[test]
     fn works_at_page_boundary() {
-        // PCMP*STR instructions are known to read 16 bytes at a time.
+        // PCMP*STR* instructions are known to read 16 bytes at a time.
         // This behaviour may cause accidental segfaults by reading
-        // past page boundary.
+        // past the page boundary.
         //
         // For now, this test crashes the whole test suite.
         // This could be fixed by setting a custom signal handlers,
-        // though Rust lacks such facilities ATM.
+        // though Rust lacks such facilities at the moment.
 
         // Allocate a 16-byte string at page boundary.
-        // To verify this test, set protect=false, that would prevent segfaults.
-        let text = unsafe {alloc_guarded_string("0123456789abcdef", true)};
+        // To verify this test, set protect=false to prevent segfaults.
+        let text = alloc_guarded_string("0123456789abcdef", true);
 
         // Will search for the last char
         let mut needle = AsciiChars::new();
@@ -364,8 +359,7 @@ mod test {
 
         // Check all suffixes of our 16-byte string
         for offset in 0..text.len() {
-            println!("Testing END{:?}", offset);
-            let tail = text.slice_chars(offset, text.len());
+            let tail = &text[offset..];
             assert_eq!(Some(tail.len() - 1), needle.find(tail));
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,6 +294,11 @@ mod test {
         assert_eq!(None,    XML_DELIM_5.find(""));
     }
 
+    #[cfg(target_os = "macos")]
+    const MAP_ANONYMOUS: libc::int32_t = libc::MAP_ANON;
+    #[cfg(not(target_os = "macos"))]
+    const MAP_ANONYMOUS: libc::int32_t = libc::MAP_ANONYMOUS;
+
     unsafe fn alloc_guarded_string(value: &str, protect: bool) -> &'static str {
         // Allocate a (leaked) pointer to a copy of value with protected end,
         // i.e. returned copy is guaranteed to be aligned to page end,
@@ -314,7 +319,7 @@ mod test {
             /* addr   = */ 0 as *mut libc::c_void,
             /* length = */ 2 * PAGE_SIZE as libc::size_t,
             /* prot   = */ libc::PROT_READ | libc::PROT_WRITE,
-            /* flags  = */ libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+            /* flags  = */ libc::MAP_PRIVATE | MAP_ANONYMOUS,
             /* fd     = */ -1,
             /* offset = */ 0,
         );


### PR DESCRIPTION
Thanks to the test from @borman, we now better handle this nasty edge case! @borman, if you have a second, I'd appreciate your eyes on my changes. If not, that's fine too!

I also cleaned up your submitted tests to make them a bit more Rust-like. If you have any questions, I'd be more than happy to drop some knowledge on you, in return for the gifts you gave me!
