### PR TITLE
Use cross-platform crates for page boundary tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,6 @@ pattern = []
 
 [dev-dependencies]
 proptest = "0.8.3"
-libc = "0.2"
 lazy_static = "1.0.0"
+region = "1.0.0"
+memmap = "0.7.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,10 +145,12 @@
 #[macro_use]
 extern crate lazy_static;
 #[cfg(test)]
-extern crate libc;
+extern crate memmap;
 #[cfg(test)]
 #[macro_use]
 extern crate proptest;
+#[cfg(test)]
+extern crate region;
 
 use std::marker::PhantomData;
 


### PR DESCRIPTION
Fixes #29.