### PR TITLE
ByteSubstring: add an option to used an owned needle (not borrowed)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,6 +11,10 @@ fn main() {
 }
 
 fn cfg() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_ARCH");
+    println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_FEATURE");
+
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
     let target_feature = env::var("CARGO_CFG_TARGET_FEATURE").unwrap_or_default();
 

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -21,23 +21,26 @@ where
     }
 }
 
-pub struct ByteSubstring<'a> {
-    needle: &'a [u8],
+pub struct ByteSubstring<T> {
+    needle: T,
 }
 
-impl<'a> ByteSubstring<'a> {
-    pub /* const */ fn new(needle: &'a[u8]) -> Self {
+impl<T> ByteSubstring<T>
+where
+    T: AsRef<[u8]>,
+{
+    pub /* const */ fn new(needle: T) -> Self {
         ByteSubstring { needle }
     }
 
     #[cfg(feature = "pattern")]
     pub fn needle_len(&self) -> usize {
-        self.needle.len()
+        self.needle.as_ref().len()
     }
 
     pub fn find(&self, haystack: &[u8]) -> Option<usize> {
         haystack
-            .windows(self.needle.len())
-            .position(|window| window == self.needle)
+            .windows(self.needle.as_ref().len())
+            .position(|window| window == self.needle.as_ref())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,7 +259,7 @@ where
 /// A convenience type that can be used in a constant or static.
 pub type AsciiCharsConst = AsciiChars<fn(u8) -> bool>;
 
-/// Searches a slice for the first occurence of the subslice.
+/// Searches a slice for the first occurrence of the subslice.
 pub enum ByteSubstring<T> {
     #[cfg(any(jetscii_sse4_2 = "yes", jetscii_sse4_2 = "maybe"))]
     SIMD(simd::ByteSubstring<T>),
@@ -301,7 +301,7 @@ where
         }
     }
 
-    /// Searches the slice for the first occurence of the subslice.
+    /// Searches the slice for the first occurrence of the subslice.
     #[inline]
     pub fn find(&self, haystack: &[u8]) -> Option<usize> {
         match self {
@@ -340,7 +340,7 @@ where
         self.0.needle_len()
     }
 
-    /// Searches the string for the first occurence of the substring.
+    /// Searches the string for the first occurrence of the substring.
     #[inline]
     pub fn find(&self, haystack: &str) -> Option<usize> {
         self.0.find(haystack.as_bytes())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,16 +282,19 @@ where
 pub type AsciiCharsConst = AsciiChars<fn(u8) -> bool>;
 
 /// Searches a slice for the first occurence of the subslice.
-pub struct ByteSubstring<'a> {
+pub struct ByteSubstring<T> {
     #[cfg(any(jetscii_sse4_2 = "yes", jetscii_sse4_2 = "maybe"))]
     simd: simd::ByteSubstring<'a>,
 
     #[cfg(any(jetscii_sse4_2 = "maybe", jetscii_sse4_2 = "no"))]
-    fallback: fallback::ByteSubstring<'a>,
+    fallback: fallback::ByteSubstring<T>,
 }
 
-impl<'a> ByteSubstring<'a> {
-    pub /* const */ fn new(needle: &'a [u8]) -> Self {
+impl<T> ByteSubstring<T>
+where
+    T: AsRef<[u8]>,
+{
+    pub /* const */ fn new(needle: T) -> Self {
         ByteSubstring {
             #[cfg(any(jetscii_sse4_2 = "yes", jetscii_sse4_2 = "maybe"))]
             simd: simd::ByteSubstring::new(needle),
@@ -320,10 +323,10 @@ impl<'a> ByteSubstring<'a> {
 }
 
 /// A convenience type that can be used in a constant or static.
-pub type ByteSubstringConst = ByteSubstring<'static>;
+pub type ByteSubstringConst = ByteSubstring<&'static [u8]>;
 
 /// Searches a string for the first occurence of the substring.
-pub struct Substring<'a>(ByteSubstring<'a>);
+pub struct Substring<'a>(ByteSubstring<&'a [u8]>);
 
 impl<'a> Substring<'a> {
     pub /* const */ fn new(needle: &'a str) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,14 +325,25 @@ where
 /// A convenience type that can be used in a constant or static.
 pub type ByteSubstringConst = ByteSubstring<&'static [u8]>;
 
-/// Searches a string for the first occurence of the substring.
-pub struct Substring<'a>(ByteSubstring<&'a [u8]>);
+/// Searches a string for the first occurrence of the substring.
+pub struct Substring<T>(ByteSubstring<T>);
 
-impl<'a> Substring<'a> {
+impl<'a> Substring<&'a [u8]> {
     pub /* const */ fn new(needle: &'a str) -> Self {
         Substring(ByteSubstring::new(needle.as_bytes()))
     }
+}
 
+impl Substring<Vec<u8>> {
+    pub fn new_owned(needle: String) -> Self {
+        Substring(ByteSubstring::new(needle.into_bytes()))
+    }
+}
+
+impl<T> Substring<T>
+where
+    T: AsRef<[u8]>,
+{
     #[cfg(feature = "pattern")]
     fn needle_len(&self) -> usize {
         self.0.needle_len()
@@ -346,7 +357,7 @@ impl<'a> Substring<'a> {
 }
 
 /// A convenience type that can be used in a constant or static.
-pub type SubstringConst = Substring<'static>;
+pub type SubstringConst = Substring<&'static [u8]>;
 
 #[cfg(all(test, feature = "benchmarks"))]
 mod bench {
@@ -479,7 +490,7 @@ mod bench {
     }
 
     lazy_static! {
-        static ref XYZZY: Substring<'static> = Substring::new("xyzzy");
+        static ref XYZZY: SubstringConst = Substring::new("xyzzy");
     }
 
     fn bench_substring<F>(b: &mut test::Bencher, f: F)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,6 +349,10 @@ where
 
 /// A convenience type that can be used in a constant or static.
 pub type SubstringConst = Substring<&'static [u8]>;
+/// A convenience type to save the need to specify that the inner object is a slice.
+pub type SubstringRef<'a> = Substring<&'a [u8]>;
+/// A convenience type to save the need to specify that the inner object is owned.
+pub type SubstringOwned = Substring<Vec<u8>>;
 
 #[cfg(all(test, feature = "benchmarks"))]
 mod bench {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,6 @@
 //! | <code>s.find("xyzzy")</code>                     | 5391 MB/s      |
 
 #[cfg(test)]
-#[macro_use]
 extern crate lazy_static;
 #[cfg(test)]
 extern crate memmap;
@@ -349,6 +348,7 @@ pub type SubstringConst = Substring<'static>;
 #[cfg(all(test, feature = "benchmarks"))]
 mod bench {
     extern crate test;
+    use lazy_static::lazy_static;
 
     use super::*;
 

--- a/src/simd.rs
+++ b/src/simd.rs
@@ -320,6 +320,7 @@ mod test {
     use std::{fmt, str};
     use memmap::MmapMut;
     use region::Protection;
+    use lazy_static::lazy_static;
 
     use super::*;
 


### PR DESCRIPTION
This PR is a suggestion. I have done a minimal implementation, just so we have something to discuss.

The problem I was facing was that I couldn't use a borrowed `ByteSubstring`. So, I've modified jetscii's code to accept a `Cow` object.

Let me know what you think and if there're are any more modifications you would like to see as part of this PR.