### PR TITLE
Fix buffer overflows in find

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -16,6 +16,11 @@ inputs:
     required: false
     type: string
 
+  rustdocflags:
+    default: ""
+    required: false
+    type: string
+
   target:
     default: ""
     required: false
@@ -43,6 +48,7 @@ runs:
       uses: actions-rs/cargo@v1
       env:
         RUSTFLAGS: "${{ env.RUSTFLAGS }} ${{ inputs.rustflags }}"
+        RUSTDOCFLAGS: "${{ env.RUSTDOCFLAGS }} ${{ inputs.rustdocflags }}"
       with:
         command: test
         args: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,17 @@ jobs:
         with:
           rustflags: "-C target-feature=${{ matrix.target_feature }}"
           target: "${{ matrix.target }}"
+
+  sanitizers:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Run tests
+        uses: ./.github/actions/test
+        with:
+          toolchain: nightly
+          rustflags: "-Z sanitizer=address"
+          rustdocflags: "-Z sanitizer=address"


### PR DESCRIPTION
The previous implementation only did reads in batches of 16 bytes, which
could overflow immediately in the misalignment branch, and if there was
any haystack left after the main chunk loop, the last read would
overflow there as well.

Found by running tests with RUSTFLAGS=-Zsanitizer=address