### PR TITLE
Remove usage of actions-rs from CI

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -26,17 +26,27 @@ inputs:
     required: false
     type: string
 
+  cross-target:
+    default: ""
+    required: false
+    type: string
+
 runs:
   using: "composite"
   steps:
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ inputs.toolchain }}
-        profile: minimal
-        default: true
+
+    - name: Install cross
+      if: ${{ inputs.cross-target != '' }}
+      shell: bash
+      run: |
+        cargo install cross --git https://github.com/cross-rs/cross
 
     - name: Configure cross
+      if: ${{ inputs.cross-target != '' }}
       shell: bash
       run: |
         cat > Cross.toml <<EOF
@@ -45,14 +55,16 @@ runs:
         EOF
 
     - name: Run tests
-      uses: actions-rs/cargo@v1
       env:
         RUSTFLAGS: "${{ env.RUSTFLAGS }} ${{ inputs.rustflags }}"
         RUSTDOCFLAGS: "${{ env.RUSTDOCFLAGS }} ${{ inputs.rustdocflags }}"
-      with:
-        command: test
-        args: >-
-          --all
-          ${{ inputs.features != '' && format('--features {0}', inputs.features) || '' }}
-          ${{ inputs.target != '' && format('--target {0}', inputs.target) || '' }}
-        use-cross: ${{ inputs.target != '' }}
+      shell: bash
+      run: |
+        cmd=$([ -z "${{ inputs.cross-target }}" ] && echo 'cargo' || echo 'cross');
+
+        $cmd test \
+          --all \
+          ${{ inputs.features != '' && format('--features {0}', inputs.features) || '' }} \
+          ${{ inputs.target != '' && format('--target {0}', inputs.target) || '' }} \
+          ${{ inputs.cross-target != '' && format('--target {0}', inputs.cross-target) || '' }} \
+          ;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         target_feature: ["-sse4.2", "+sse4.2"]
-        target: ["", "i686-unknown-linux-gnu"]
+        cross-target: ["", "i686-unknown-linux-gnu"]
 
     runs-on: ubuntu-latest
 
@@ -65,7 +65,7 @@ jobs:
         uses: ./.github/actions/test
         with:
           rustflags: "-C target-feature=${{ matrix.target_feature }}"
-          target: "${{ matrix.target }}"
+          cross-target: "${{ matrix.cross-target }}"
 
   sanitizers:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Additionally, split out installing cross from running the tests. This might allow us to more easily run the sanitizers for a more complicated benchmark using Criterion.