### PR TITLE
const `ByteSubstring::new`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,8 @@ fn cfg() {
     let ok_arch = matches!(&*target_arch, "x86" | "x86_64");
     let sse4_2_guaranteed = target_feature.split(',').any(|f| f == "sse4.2");
 
+    println!("cargo::rustc-check-cfg=cfg(jetscii_sse4_2, values(\"yes\", \"maybe\", \"no\"))");
+
     if sse4_2_guaranteed {
         println!(r#"cargo:rustc-cfg=jetscii_sse4_2="yes""#);
     } else if ok_arch {

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -26,7 +26,7 @@ pub struct ByteSubstring<'a> {
 }
 
 impl<'a> ByteSubstring<'a> {
-    pub /* const */ fn new(needle: &'a[u8]) -> Self {
+    pub const fn new(needle: &'a[u8]) -> Self {
         ByteSubstring { needle }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,7 +292,7 @@ pub struct ByteSubstring<'a> {
 }
 
 impl<'a> ByteSubstring<'a> {
-    pub /* const */ fn new(needle: &'a [u8]) -> Self {
+    pub const fn new(needle: &'a [u8]) -> Self {
         ByteSubstring {
             #[cfg(any(jetscii_sse4_2 = "yes", jetscii_sse4_2 = "maybe"))]
             simd: simd::ByteSubstring::new(needle),

--- a/src/simd.rs
+++ b/src/simd.rs
@@ -267,12 +267,18 @@ pub struct ByteSubstring<'a> {
 }
 
 impl<'a> ByteSubstring<'a> {
-    pub /* const */ fn new(needle: &'a[u8]) -> Self {
-        use std::cmp;
-
+    pub const fn new(needle: &'a[u8]) -> Self {
         let mut simd_needle = [0; 16];
-        let len = cmp::min(simd_needle.len(), needle.len());
-        simd_needle[..len].copy_from_slice(&needle[..len]);
+        let len = if simd_needle.len() < needle.len() {
+            simd_needle.len()
+        } else {
+            needle.len()
+        };
+        let mut i = 0;
+        while i < len {
+            simd_needle[i] = needle[i];
+            i += 1;
+        }
         ByteSubstring {
             complete_needle: needle,
             needle: unsafe { TransmuteToSimd { bytes: simd_needle }.simd },


### PR DESCRIPTION
hey - looks like this was at least planned at some point, since `/* const */` keyword was commented out in a few places. 

are you interested in merging something like this? 

seems like the `const` version of the `simd` code is a bit uglier, but equivalent. if there are concerns about the `const` version of the code in `new` not being as fast, perhaps there could be a `impl<'static> ByteSubstring<'static>` block with a `new_static` method or something.